### PR TITLE
[web] [css] Change block size of header and footer

### DIFF
--- a/web/src/assets/styles/variables.scss
+++ b/web/src/assets/styles/variables.scss
@@ -62,6 +62,6 @@
 
   --icon-size-m: 32px;
 
-  --header-block-size: 6vh;
-  --footer-block-size: 8vh;
+  --header-block-size: min-content;
+  --footer-block-size: min-content;
 }


### PR DESCRIPTION
Now it uses `min-content` instead of a viewport percentage length unit to avoid ugly content overflows.

* https://www.w3.org/TR/css-sizing-3/#valdef-width-min-content
* https://www.w3.org/TR/css-values-3/#viewport-relative-lengths


## Problem

*Short description of the original problem.*

- *Bugzilla link*
- *openQA link*
- *Links to other related pull requests*


## Solution

*Short description of the fix.*


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

